### PR TITLE
Excluded MaximumIneritanceDepth rule from Sonarqube rules

### DIFF
--- a/tap-project/pom.xml
+++ b/tap-project/pom.xml
@@ -21,6 +21,10 @@
 		<sonar.language>java</sonar.language>
 		<sonar.jacoco.reportPath>${jacoco.data.file.UT}</sonar.jacoco.reportPath>
 		<sonar.jacoco.itReportPath>${jacoco.data.file.IT}</sonar.jacoco.itReportPath>
+		<sonar.issue.ignore.multicriteria>e11</sonar.issue.ignore.multicriteria>
+		<sonar.issue.ignore.multicriteria.e11.ruleKey>squid:MaximumInheritanceDepth</sonar.issue.ignore.multicriteria.e11.ruleKey>
+		<sonar.issue.ignore.multicriteria.e11.resourceKey>**/*.java</sonar.issue.ignore.multicriteria.e11.resourceKey>
+
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
Configured pom.xml so that Sonarqube won't consider the
MaximumIneritanceDepth rule (since it gives false positive for the UI
classes)